### PR TITLE
ConfigMaps + Secrets

### DIFF
--- a/drpsychick/cronjobs/README.md
+++ b/drpsychick/cronjobs/README.md
@@ -29,10 +29,48 @@ helm search repo drpsychick
 helm upgrade --create-namespace --namespace test --install --values values.yaml jobs drpsychick/cronjobs
 ```
 
+### ConfigMaps and Secrets for scripts and data
+* mounted as `/configMaps/{{ name }}` and `/secrets/{{ name }}` respectively
+
+#### Existing configMap
+Use an existing configMap in your cronjobs, it will be available at `/configMaps/global-configmap/`
+```yaml
+customConfigMap: global-configmap
+```
+
+#### Files from strings
+Hint: you can load larger files from separate `yaml` files.
+
+Example: 
+`helm template example cronjobs --debug --values cronjobs/ci/values-configMaps.yaml,cronjobs/ci/values-config1.yaml`
+
+```yaml
+configMaps:
+  scripts:
+    data:
+      script.sh: |-
+        #!/bin/sh
+        echo "foo"
+```
+
+#### Files from files which are within the chart directory
+```yaml
+configMaps:
+  from-files:
+    files:
+      example.sh: ci/files/example.sh
+
+secrets:
+  ssh-creds:
+    files:
+      id-rsa.pub: ci/files/id-rsa.pub
+```
+
+
 ## Missing features - help appreciated
 * [ ] allow overwriting `nodeSelector, affinity, ...`
 * [ ] add charts ci pipeline
-* [ ] add support for scripts via `configMap`
+* [x] add support for scripts + secrets via `ConfigMap` and `Secret`
 * [ ] add support for `volumes` + `volumeMounts`
 * [ ] add some specific examples
 

--- a/drpsychick/cronjobs/ci/files/example.sh
+++ b/drpsychick/cronjobs/ci/files/example.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "This script is included with '.Files.Get'"
+echo "Helm can only access files in the chart directory with this method."

--- a/drpsychick/cronjobs/ci/files/id-rsa.pub
+++ b/drpsychick/cronjobs/ci/files/id-rsa.pub
@@ -1,0 +1,1 @@
+ssh-rsa AAAAB3N.....uFo42 your@key.comment

--- a/drpsychick/cronjobs/ci/values-config1.yaml
+++ b/drpsychick/cronjobs/ci/values-config1.yaml
@@ -1,0 +1,8 @@
+# use extra values files to separate config and scripts
+configMaps:
+  config1:
+    data:
+      test.txt: |-
+        some text
+
+        and some more

--- a/drpsychick/cronjobs/ci/values-configMaps.yaml
+++ b/drpsychick/cronjobs/ci/values-configMaps.yaml
@@ -1,0 +1,36 @@
+# example values for configMaps
+
+configMaps:
+  # name of the configMap
+  config:
+    data:
+      config.ini: |-
+        # config
+        [global]
+          mykey = value
+  scripts:
+    data:
+      start.sh: |-
+        #!/bin/sh
+        trap 'echo "quitting."' QUIT
+
+        echo "starting..."
+        sleep 5
+    # from files: requires files to be in the chart directory!
+    # it's easier to use separate yaml files
+    # see https://github.com/helm/helm/issues/3276#issuecomment-353066972
+    files:
+      example.sh: ci/files/example.sh
+
+jobs:
+  - name: start
+    schedule: "*/15 * * * *"
+    command:
+      - /bin/sh
+    args:
+      - /configMaps/scripts/start.sh
+    image:
+      repository: alpine
+  - name: cat
+    schedule: "*/5 * * * *"
+    command: ["cat", "/configMaps/config/config.ini"]

--- a/drpsychick/cronjobs/ci/values-secrets.yaml
+++ b/drpsychick/cronjobs/ci/values-secrets.yaml
@@ -1,0 +1,12 @@
+secrets:
+  # strings and file contents are automatically base64 encoded
+  ssh-creds:
+    data:
+      ssh.key: "ssh-rsa AAAAB3N.....uFo42 your@key.comment"
+    files:
+      id-rsa.pub: ci/files/id-rsa.pub
+
+jobs:
+  - name: print-secret
+    schedule: "*/5 * * * *"
+    command: ["cat", "/secrets/ssh-cred/ssh.key", "/secrets/ssh-cred/id-rsa.pub"]

--- a/drpsychick/cronjobs/templates/configmap.yaml
+++ b/drpsychick/cronjobs/templates/configmap.yaml
@@ -1,0 +1,25 @@
+{{- $chart_name := include "cronjobs.fullname" . }}
+{{- $chart_labels := include "cronjobs.labels" . }}
+
+{{- if .Values.configMaps }}
+{{- range $name, $map := .Values.configMaps }}
+{{- $checksum := toYaml $map | sha256sum | trunc 20 | quote }}
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: {{ $chart_name }}-{{ $name }}
+  labels:
+    {{- $chart_labels | nindent 4 }}
+  annotations:
+    values/checksum: {{ $checksum }}
+data:
+  {{- with $map.data }}
+  {{- toYaml . | nindent 2}}
+  {{- end }}
+  {{- range $name, $path := $map.files }}
+  {{ $name }}: |-
+    {{- $.Files.Get $path | nindent 4}}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/drpsychick/cronjobs/templates/cronjob.yaml
+++ b/drpsychick/cronjobs/templates/cronjob.yaml
@@ -61,7 +61,7 @@ spec:
           {{- with default $image_pull_secrets .imagePullSecrets }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if $.Values.secrets.dockerConfigJson }}
+          {{- if $.Values.dockerConfigJson }}
             - name: {{ $chart_name }}-registry
           {{- end }}
           {{- if $.Values.serviceAccount.create }}
@@ -113,19 +113,16 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumes:
-            # global custom configMap
             {{- if $.Values.customConfigMap }}
             - name: {{ $.Values.customConfigMap }}
               configMap:
                 name: {{ $.Values.customConfigMap }}
             {{- end }}
-            # global configMaps
             {{- range $name, $map := $.Values.configMaps }}
             - name: {{ $name }}
               configMap:
                 name: {{ print $chart_name "-" $name }}
             {{- end }}
-            # global secrets
             {{- range $name, $secret := $.Values.secrets }}
             - name: {{ $name }}
               secret:

--- a/drpsychick/cronjobs/templates/cronjob.yaml
+++ b/drpsychick/cronjobs/templates/cronjob.yaml
@@ -87,6 +87,19 @@ spec:
                 {{- toYaml $env | nindent 16 }}
               resources:
                 {{- toYaml $.Values.resources | nindent 16 }}
+              volumeMounts:
+                {{- if $.Values.customConfigMap }}
+                - mountPath: /configMaps/{{ $.Values.customConfigMap }}
+                  name: {{ $.Values.customConfigMap }}
+                {{- end }}
+                {{- range $name, $map := $.Values.configMaps }}
+                - mountPath: /configMaps/{{ $name }}
+                  name: {{ $name }}
+                {{- end }}
+                {{- range $name, $secret := $.Values.secrets }}
+                - mountPath: /secrets/{{ $name }}
+                  name: {{ $name }}
+                {{- end }}
           {{- with $.Values.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
@@ -99,4 +112,23 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-{{- end }}
+          volumes:
+            # global custom configMap
+            {{- if $.Values.customConfigMap }}
+            - name: {{ $.Values.customConfigMap }}
+              configMap:
+                name: {{ $.Values.customConfigMap }}
+            {{- end }}
+            # global configMaps
+            {{- range $name, $map := $.Values.configMaps }}
+            - name: {{ $name }}
+              configMap:
+                name: {{ print $chart_name "-" $name }}
+            {{- end }}
+            # global secrets
+            {{- range $name, $secret := $.Values.secrets }}
+            - name: {{ $name }}
+              secret:
+                secretName: {{ print $chart_name "-" $name }}
+            {{- end }}
+  {{- end }}

--- a/drpsychick/cronjobs/templates/secrets.yaml
+++ b/drpsychick/cronjobs/templates/secrets.yaml
@@ -1,13 +1,37 @@
-{{- if hasKey .Values.secrets "dockerConfigJson" }}
+{{- $chart_name := include "cronjobs.fullname" . }}
+{{- $chart_labels := include "cronjobs.labels" . }}
+
+{{- if .Values.dockerConfigJson }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cronjobs.fullname" . }}-registry
+  name: {{ $chart_name }}-registry
   labels:
-    {{- include "cronjobs.labels" . | nindent 4 }}
+    {{- $chart_labels | nindent 4 }}
   annotations:
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.secrets.dockerConfigJson }}
+  .dockerconfigjson: {{ .Values.dockerConfigJson | b64enc | quote }}
+{{- end }}
+
+{{- range $name, $secret := .Values.secrets }}
+{{- $checksum := toYaml $secret | sha256sum | trunc 20 | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $chart_name }}-{{ $name }}
+  labels:
+    {{- $chart_labels | nindent 4 }}
+  annotations:
+    values/checksum: {{ $checksum }}
+type: Opaque
+data:
+  {{- range $name, $value := $secret.data }}
+  {{ $name }}: {{ $value | b64enc | quote }}
+  {{- end }}
+  {{- range $name, $path := $secret.files }}
+  {{ $name }}: {{ $.Files.Get $path | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/drpsychick/cronjobs/templates/secrets.yaml
+++ b/drpsychick/cronjobs/templates/secrets.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.dockerConfigJson | b64enc | quote }}
+  .dockerconfigjson: {{ .Values.dockerConfigJson | quote }}
 {{- end }}
 
 {{- range $name, $secret := .Values.secrets }}

--- a/drpsychick/cronjobs/values.yaml
+++ b/drpsychick/cronjobs/values.yaml
@@ -14,7 +14,8 @@ imagePullSecrets: []
 # and add it to imagePullSecrets
 # i.e.
 # AUTH=$( echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64 )
-#dockerConfigJson: '{ "auths": { "${REGISTRY_URL}": { "auth": "${AUTH}" } } }'
+# DOCKER_CONFIG_JSON=$(echo -n '{ "auths": { "${REGISTRY_URL}": { "auth": "${AUTH}" } } }' | base64 -w0)
+#dockerConfigJson: $DOCKER_CONFIG_JSON
 
 secrets: {}
 #  # strings and file contents are automatically base64 encoded

--- a/drpsychick/cronjobs/values.yaml
+++ b/drpsychick/cronjobs/values.yaml
@@ -14,7 +14,7 @@ imagePullSecrets: []
 # and add it to imagePullSecrets
 # i.e.
 # AUTH=$( echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64 )
-# DOCKER_CONFIG_JSON=$(echo -n '{ "auths": { "${REGISTRY_URL}": { "auth": "${AUTH}" } } }' | base64 -w0)
+# DOCKER_CONFIG_JSON=$(echo -n '{ "auths": { "${REGISTRY_URL}": { "auth": "${AUTH}" } } }' | base64)
 #dockerConfigJson: $DOCKER_CONFIG_JSON
 
 secrets: {}

--- a/drpsychick/cronjobs/values.yaml
+++ b/drpsychick/cronjobs/values.yaml
@@ -14,7 +14,7 @@ imagePullSecrets: []
 # and add it to imagePullSecrets
 # i.e.
 # AUTH=$( echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64 )
-# DOCKER_CONFIG_JSON=$(echo -n '{ "auths": { "${REGISTRY_URL}": { "auth": "${AUTH}" } } }' | base64)
+# DOCKER_CONFIG_JSON=$(echo -n '{ "auths": { "${REGISTRY_URL}": { "auth": "${AUTH}" } } }' | base64 | tr -d \"\n\")
 #dockerConfigJson: $DOCKER_CONFIG_JSON
 
 secrets: {}

--- a/drpsychick/cronjobs/values.yaml
+++ b/drpsychick/cronjobs/values.yaml
@@ -9,13 +9,45 @@ image:
   tag: latest
 
 imagePullSecrets: []
+
+# will create a kubernetes.io/dockerconfigjson secret
+# and add it to imagePullSecrets
+# i.e.
+# AUTH=$( echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64 )
+#dockerConfigJson: '{ "auths": { "${REGISTRY_URL}": { "auth": "${AUTH}" } } }'
+
 secrets: {}
-  # will create a kubernetes.io/dockerconfigjson secret
-  # and add it to imagePullSecrets
-  # i.e.
-  # AUTH=$( echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64 )
-  # DOCKER_CONFIG_JSON=$(echo '{ \"auths\": { \"'${REGISTRY_URL}'\": { \"auth\": \"'$AUTH'\" } } }' | base64 | tr -d \"\n\" )"
-  #dockerConfigJson: $DOCKER_CONFIG_JSON
+#  # strings and file contents are automatically base64 encoded
+#  ssh-creds:
+#    data:
+#      ssh.key: "ssh-rsa AAAAB3N.....uFo42 your@key.comment"
+#    files:
+#      id-rsa.pub: ci/files/id-rsa.pub
+
+# a global custom configMap that is mounted in every job
+customConfigMap:
+
+# global configMaps from string or files
+configMaps: {}
+#  # name of the configMap
+#  config:
+#    data:
+#      # everything below is uses "as-is" in the configMap
+#      config.ini: |-
+#        # config
+#        [global]
+#          mykey = value
+#      cert.key: "<base64 encoded certificate>"
+#  scripts:
+#    data:
+#      start.sh: |-
+#        #!/bin/sh
+#        trap 'echo "quitting"' QUIT
+#    # from files: requires files to be in the chart directory!
+#    # it's easier to use separate yaml files
+#    # see https://github.com/helm/helm/issues/3276#issuecomment-353066972
+#    files:
+#      example.sh: ci/files/example.sh
 
 # environment variables for all jobs
 env: []


### PR DESCRIPTION
Support, but only globally for all `jobs` for now
* existing `customConfigMap`
* mounting files from definition as strings in `configMaps` and `secrets`
* mounting files from files within the chart directory

To keep large files separate, just use multiple `yaml` files that you pass to helm:
`helm upgrade [...] --values values.yaml,configmaps.yaml,secret1.yaml,secret2.yaml`

see https://github.com/helm/helm/issues/3276#issuecomment-353066972